### PR TITLE
Support trustedTesters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,12 @@ $ webstore --help
 
   Options
     --source          Path to either a zip file, or a directory to be zipped (Defaults to cwd if not specified)
-    --extension-id    The ID of the Chrome Extension
-    --client-id       OAuth2 Client ID
-    --client-secret   OAuth2 Client Secret
-    --refresh-token   OAuth2 Refresh Token
-    --auto-publish    Can be used with the "upload" command
+    --extension-id      The ID of the Chrome Extension
+    --client-id         OAuth2 Client ID
+    --client-secret     OAuth2 Client Secret
+    --refresh-token     OAuth2 Refresh Token
+    --auto-publish      Can be used with the "upload" command
+    --trusted-testers   Can be used with the "publish" command
 
   Examples
     Upload new extension archive to the Chrome Web Store

--- a/config.js
+++ b/config.js
@@ -11,6 +11,7 @@ module.exports = function(command, flags) {
         zipPath: flags.source,
         isUpload: command === 'upload',
         isPublish: command === 'publish',
-        autoPublish: flags.autoPublish
+        autoPublish: flags.autoPublish,
+        trustedTesters: flags.trustedTesters
     };
 };

--- a/index.js
+++ b/index.js
@@ -21,12 +21,12 @@ const cli = meow(`
         upload, publish
 
     Options
-      --source          Path to either a zip file, or a directory to be zipped
-      --extension-id    The ID of the Chrome Extension
-      --client-id       OAuth2 Client ID
-      --client-secret   OAuth2 Client Secret
-      --refresh-token   OAuth2 Refresh Token
-      --auto-publish    Can be used with the "upload" command
+      --source             Path to either a zip file, or a directory to be zipped
+      --extension-id       The ID of the Chrome Extension
+      --client-id          OAuth2 Client ID
+      --client-secret      OAuth2 Client Secret
+      --refresh-token      OAuth2 Refresh Token
+      --auto-publish       Can be used with the "upload" command
       --trusted-testers    Can be used with the "publish" command
 
 

--- a/index.js
+++ b/index.js
@@ -27,6 +27,8 @@ const cli = meow(`
       --client-secret   OAuth2 Client Secret
       --refresh-token   OAuth2 Refresh Token
       --auto-publish    Can be used with the "upload" command
+      --trusted-testers    Can be used with the "publish" command
+
 
     Examples
       Upload new extension archive to the Chrome Web Store
@@ -52,7 +54,8 @@ const {
     zipPath,
     isUpload,
     isPublish,
-    autoPublish
+    autoPublish,
+    trustedTesters
 } = createConfig(cli.input[0], cli.flags);
 
 const spinner = ora();
@@ -103,7 +106,8 @@ if (isUpload) {
 
 if (isPublish) {
     spinnerStart('Publishing');
-    publish({ apiConfig }).then(res => {
+
+    publish({ apiConfig }, trustedTesters ? "trustedTesters" : undefined ).then(res => {
         spinner.stop();
         exitWithPublishStatus(res);
     }).catch(errorHandler);

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ if (isUpload && autoPublish) {
             }
 
             spinnerStart('Publishing');
-            return publish({ apiConfig, token }).then(publishRes => {
+            return publish({ apiConfig, token }, trustedTesters && 'trustedTesters').then(publishRes => {
                 spinner.stop();
                 exitWithPublishStatus(publishRes);
             });

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ if (isUpload) {
 if (isPublish) {
     spinnerStart('Publishing');
 
-    publish({ apiConfig }, trustedTesters ? "trustedTesters" : undefined ).then(res => {
+    publish({ apiConfig }, trustedTesters && 'trustedTesters').then(res => {
         spinner.stop();
         exitWithPublishStatus(res);
     }).catch(errorHandler);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "chalk": "^1.1.3",
-    "chrome-webstore-upload": "DrewML/chrome-webstore-upload#trusted_testers",
+    "chrome-webstore-upload": "^0.2.0",
     "junk": "^1.0.2",
     "meow": "^3.7.0",
     "ora": "^0.2.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "chalk": "^1.1.3",
-    "chrome-webstore-upload": "^0.2.0",
+    "chrome-webstore-upload": "DrewML/chrome-webstore-upload#trusted_testers",
     "junk": "^1.0.2",
     "meow": "^3.7.0",
     "ora": "^0.2.3",

--- a/wrapper.js
+++ b/wrapper.js
@@ -30,7 +30,7 @@ module.exports = {
         });
     },
 
-    publish({ apiConfig, token }) {
+    publish({ apiConfig, token }, publishTarget) {
         let client;
         try {
             client = getClient(apiConfig);
@@ -38,7 +38,7 @@ module.exports = {
             return Promise.reject(err);
         }
 
-        return client.publish(undefined, token);
+        return client.publish(publishTarget, token);
     },
 
     fetchToken(apiConfig) {
@@ -48,7 +48,7 @@ module.exports = {
         } catch(err) {
             return Promise.reject(err);
         }
-        
+
         return client.fetchToken();
     }
 };


### PR DESCRIPTION
Hi there!

Thanks a lot for making this great CLI tool! In this PR, I added a `trusted-testers` option to the CLI to be used with the `publish` command so that we can use this to support publishing to trusted testers only.

Let me know what you think!

Fixes #26 