### PR TITLE
Add --target option for publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ $ webstore --help
     --client-secret   OAuth2 Client Secret
     --refresh-token   OAuth2 Refresh Token
     --auto-publish    Can be used with the "upload" command
+    --target          Extension publish target; can be used with "publish" or "upload --auto-publish" command
 
   Examples
     Upload new extension archive to the Chrome Web Store

--- a/config.js
+++ b/config.js
@@ -8,6 +8,7 @@ module.exports = function(command, flags) {
 
     return {
         apiConfig,
+        target: flags.target || process.env.EXTENSION_TARGET
         zipPath: flags.source,
         isUpload: command === 'upload',
         isPublish: command === 'publish',

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ const cli = meow(`
       --client-secret   OAuth2 Client Secret
       --refresh-token   OAuth2 Refresh Token
       --auto-publish    Can be used with the "upload" command
+      --target          Target for publishing (default, trustedTesters etc.)
 
     Examples
       Upload new extension archive to the Chrome Web Store
@@ -49,6 +50,7 @@ if (preliminaryValidation.error) {
 
 const {
     apiConfig,
+    target,
     zipPath,
     isUpload,
     isPublish,
@@ -78,7 +80,7 @@ if (isUpload && autoPublish) {
             }
 
             spinnerStart('Publishing');
-            return publish({ apiConfig, token }).then(publishRes => {
+            return publish({ apiConfig, token, target }).then(publishRes => {
                 spinner.stop();
                 exitWithPublishStatus(publishRes);
             });
@@ -103,7 +105,7 @@ if (isUpload) {
 
 if (isPublish) {
     spinnerStart('Publishing');
-    publish({ apiConfig }).then(res => {
+    publish({ apiConfig, null, target }).then(res => {
         spinner.stop();
         exitWithPublishStatus(res);
     }).catch(errorHandler);

--- a/test/config.js
+++ b/test/config.js
@@ -13,6 +13,7 @@ test('Favors params over env vars', t => {
 test('All options supported as env vars', t => {
     const vars = [
         'EXTENSION_ID',
+        'EXTENSION_TARGET',
         'CLIENT_ID',
         'CLIENT_SECRET',
         'REFRESH_TOKEN'
@@ -23,6 +24,7 @@ test('All options supported as env vars', t => {
 
     const config = createConfig(null, {});
     t.is(config.apiConfig.extensionId, varsVal);
+    t.is(config.target, varsVal);
     t.is(config.apiConfig.clientId, varsVal);
     t.is(config.apiConfig.clientSecret, varsVal);
     t.is(config.apiConfig.refreshToken, varsVal);

--- a/wrapper.js
+++ b/wrapper.js
@@ -30,7 +30,7 @@ module.exports = {
         });
     },
 
-    publish({ apiConfig, token }) {
+    publish({ apiConfig, token, target }) {
         let client;
         try {
             client = getClient(apiConfig);
@@ -38,7 +38,7 @@ module.exports = {
             return Promise.reject(err);
         }
 
-        return client.publish(undefined, token);
+        return client.publish(target, token);
     },
 
     fetchToken(apiConfig) {


### PR DESCRIPTION
See https://github.com/DrewML/chrome-webstore-upload/issues/13

The target is supported in the API client, but not in the CLI.

I've implemented it like that so there is no need to change the client.

An alternative would be to change the client to configure the target in the constructor options instead of a parameter in the `publish()` method.

Let me know how you prefer it and what do you think of this change!

Thanks!