### PR TITLE
Add FACEIT Enhancer to the extensions using it

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The following projects use this package to facilitate auto-deployment of extensi
 - [OctoLinker](https://github.com/octolinker/browser-extension)
 - [Refined GitHub](https://github.com/sindresorhus/refined-github)
 - [Refined Twitter](https://github.com/sindresorhus/refined-twitter)
+- [FACEIT Enhancer](https://github.com/faceit-enhancer/faceit-enhancer)
 
 ## Minimum node.js version
 


### PR DESCRIPTION
First of all, thank you very much for this great CLI.

I'd like to propose to add my browser extension [FACEIT Enhancer](https://github.com/faceit-enhancer/faceit-enhancer) to the list of chrome-webstore-upload-cli users. FACEIT Enhancer is using chrome-webstore-upload-cli since the very beginning and has over 390k users and growing. chrome-webstore-upload-cli has helped FACEIT Enhancer to seamlessly upload and release to the web store for the past 2 years and is still powering the deployment process. The intention of adding FACEIT Enhancer to the list is to showcase how another extension is using chrome-webstore-upload-cli.