### PR TITLE
feat: add TypeScript type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,48 @@
+/**
+ * chrome-webstore-upload-cli - CLI tool to upload Chrome Extensions to the Chrome Web Store
+ */
+
+export interface ChromeWebStoreConfig {
+    extensionId?: string;
+    clientId?: string;
+    clientSecret?: string;
+    refreshToken?: string;
+}
+
+export interface ConfigResult {
+    apiConfig: ChromeWebStoreConfig;
+    path?: string;
+    isUpload: boolean;
+    isPublish: boolean;
+    autoPublish: boolean;
+    trustedTesters?: boolean;
+    deployPercentage?: number;
+    maxAwaitInProgress?: number;
+}
+
+export interface UploadOptions {
+    apiConfig: ChromeWebStoreConfig;
+    path: string;
+    token?: string;
+    maxAwaitInProgress?: number;
+}
+
+export interface PublishOptions {
+    apiConfig: ChromeWebStoreConfig;
+    token?: string;
+}
+
+export default function getConfig(
+    command?: string,
+    flags?: Record<string, unknown>
+): Promise<ConfigResult>;
+
+export function upload(options: UploadOptions): Promise<unknown>;
+
+export function publish(
+    options: PublishOptions,
+    publishTarget?: string,
+    deployPercentage?: number
+): Promise<unknown>;
+
+export function fetchToken(apiConfig: ChromeWebStoreConfig): Promise<unknown>;

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "chrome-webstore-upload-cli",
   "version": "4.0.0-0",
   "description": "CLI tool to upload Chrome Extensions to the Chrome Web Store",
+  "types": "index.d.ts",
   "keywords": [
     "chrome",
     "publish",


### PR DESCRIPTION
## Summary
Adds TypeScript type definitions for the `chrome-webstore-upload-cli` package (22K weekly downloads).

## Changes
- Created `index.d.ts` with type definitions for:
  - `ChromeWebStoreConfig` interface
  - `ConfigResult` interface
  - `UploadOptions` interface
  - `PublishOptions` interface
  - Functions: `getConfig`, `upload`, `publish`, `fetchToken`
- Added `types: index.d.ts` to package.json

This enables TypeScript users to use chrome-webstore-upload-cli with full type support.

## Testing
- Type definitions follow the package's ES module exports
- Compatible with TypeScript's module resolution